### PR TITLE
Fire off multiple wormholes per call

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1768,7 +1768,14 @@ function tryUsingAbility(itemId, checkInLane, forceAbility) {
 }
 
 function triggerAbility(abilityId) {
-	s().m_rgAbilityQueue.push({'ability': abilityId});
+	if (abilityId === ABILITIES.WORMHOLE) {
+		// Fire this bad boy off immediately AND SEVEN TIMES PER CALL BECAUSE GET REKT VALVE
+		for (var i = 0; i < 7; i++) {
+			g_Server.UseAbilities($J.noop, $J.noop, {requested_abilities: [{ability: ABILITIES.WORMHOLE}]});
+		}
+	} else {
+		s().m_rgAbilityQueue.push({'ability': abilityId});
+	}
 
 	var nCooldownDuration = s().m_rgTuningData.abilities[abilityId].cooldown;
 	s().ClientOverride('ability', abilityId, Math.floor(Date.now() / 1000) + nCooldownDuration);


### PR DESCRIPTION
Read #7 and then this post:

`<Novex> it's basically PR7 on coke :P`

Multiple requests will be sent within a "sane" period of time to maximize WH uses.  Initial tests show around 10 WH/s using this script.