### PR TITLE
Keep LN spammers in the right place

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -460,7 +460,8 @@ function MainLoop() {
 	if (!isAlreadyRunning) {
 		isAlreadyRunning = true;
 
-		if (level % 100 == 0 && bHaveItem(ABILITIES.WORMHOLE) ) {
+		if ((level % 100 == 0 && bHaveItem(ABILITIES.WORMHOLE))
+				|| likeNewOn100 ) {
 			// On a WH level, jump everyone with wormholes to lane 0, unless there is a boss there, in which case jump to lane 1.
 			var targetLane = 0;
 			// Check lane 0, enemy 0 to see if it's a boss


### PR DESCRIPTION
They never buy WH's, so they would always be sent to the boss.

LNers now always go in the WH lane.