### PR TITLE
Decrease CONTROL.rainingSafeRounds to 9

### DIFF
--- a/autoplay.noUpdate.user.js
+++ b/autoplay.noUpdate.user.js
@@ -164,7 +164,7 @@ var CONTROL = {
 	speedThreshold: 2000,
 	rainingRounds: 100,
 	disableGoldRainLevels: 500,
-	rainingSafeRounds: 10
+	rainingSafeRounds: 9
 };
 
 var GAME_STATUS = {


### PR DESCRIPTION
This will allow abilities and damage to still be used against x90 bosses. Right now, getting through those bosses is very slow, and gives trolls an opportunity to spam wormholes. If they deploy 11 wormholes, we miss the next x00 boss. This seems to be happening on a regular basis.

We don't know if this will actually make things better: it may be that, by not pausing on the x90 levels, we end up dealing too much damage and overflowing damage onto the x00 bosses. But I think it is worth a shot.