### PR TITLE
Trolltrack performance and autorefresh patch

### DIFF
--- a/autoplay.noUpdate.user.js
+++ b/autoplay.noUpdate.user.js
@@ -54,6 +54,8 @@ var predictTicks = 0;
 var predictJumps = 0;
 var predictLastWormholesUpdate = 0;
 
+
+
 // DO NOT MODIFY
 var isPastFirstRun = false;
 var isAlreadyRunning = false;
@@ -306,76 +308,8 @@ function firstRun() {
 		document.body.style.backgroundPosition = "0 0";
 	}
 
-	CUI.prototype.UpdateLog = function( rgLaneLog ) {
-		var abilities = this.m_Game.m_rgTuningData.abilities;
-		var level = getGameLevel();
-
-		if( !this.m_Game.m_rgPlayerTechTree ) return;
-
-		var nHighestTime = 0;
-
-		// Loop for trolltrack
-		if (window.enableTrollTrack) {
-			for(var i=rgLaneLog.length-1; i >= 0; i--) {
-				var rgEntry = rgLaneLog[i];
-
-				if( isNaN( rgEntry.time ) ) rgEntry.time = this.m_nActionLogTime + 1;
-
-				if( rgEntry.time <= this.m_nActionLogTime ) continue;
-
-				if( rgEntry.type == 'ability' ) {
-					if ( (level % 100 !== 0 && [26].indexOf(rgEntry.ability) > -1) || (level % 100 === 0 && [10, 11, 12, 15, 20].indexOf(rgEntry.ability) > -1) ) {
-						var ele = this.m_eleUpdateLogTemplate.clone();
-						$J(ele).data('abilityid', rgEntry.ability);
-						$J('.name', ele).text(rgEntry.actor_name).attr("style", "color: red; font-weight: bold;");
-						$J('.ability', ele).text(abilities[rgEntry.ability].name + " on level " + level);
-						$J('img', ele).attr('src', g_rgIconMap['ability_' + rgEntry.ability].icon);
-
-						$J(ele).v_tooltip({tooltipClass: 'ta_tooltip', location: 'top'});
-
-						this.m_eleUpdateLogContainer[0].insertBefore(ele[0], this.m_eleUpdateLogContainer[0].firstChild);
-						
-						advLog(rgEntry.actor_name + " used " + s().m_rgTuningData.abilities[ rgEntry.ability ].name + " on level " + level, 1);
-					}
-				}
-
-				if(rgEntry.time > nHighestTime) nHighestTime = rgEntry.time;
-			}
-
-		// Non-trolltrack
-		} else {
-
-			for(var i=rgLaneLog.length-1; i >= 0; i--) {
-				var rgEntry = rgLaneLog[i];
-
-				if( isNaN( rgEntry.time ) ) rgEntry.time = this.m_nActionLogTime + 1;
-
-				if( rgEntry.time <= this.m_nActionLogTime ) continue;
-
-				if( rgEntry.type == 'ability' ) {
-					var ele = this.m_eleUpdateLogTemplate.clone();
-					$J(ele).data('abilityid', rgEntry.ability);
-					$J('.name', ele).text(rgEntry.actor_name);
-					$J('.ability', ele).text(abilities[rgEntry.ability].name);
-					$J('img', ele).attr('src', g_rgIconMap['ability_' + rgEntry.ability].icon);
-
-					$J(ele).v_tooltip({tooltipClass: 'ta_tooltip', location: 'top'});
-
-					this.m_eleUpdateLogContainer[0].insertBefore(ele[0], this.m_eleUpdateLogContainer[0].firstChild);
-				}
-
-				if(rgEntry.time > nHighestTime) nHighestTime = rgEntry.time;
-			}
-		}
-		
-
-		if( nHighestTime > this.m_nActionLogTime ) this.m_nActionLogTime = nHighestTime;
-
-		var e = this.m_eleUpdateLogContainer[0];
-		while(e.children.length > 20 ) {
-			e.children[e.children.length-1].remove();
-		}
-	};
+	// Set to match preferences
+	getPreference
 
 	// Add cool background
 	$J('body.flat_page.game').css('background-image', 'url(http://i.imgur.com/P8TB236.jpg)');
@@ -433,6 +367,58 @@ function firstRun() {
 
 	isPastFirstRun = true;
 }
+
+// Valve's update
+var originalUpdateLog = CUI.prototype.UpdateLog;
+
+// The trolltrack
+var localUpdateLog = function( rgLaneLog ) {
+	var abilities = this.m_Game.m_rgTuningData.abilities;
+	var level = getGameLevel();
+
+	if( !this.m_Game.m_rgPlayerTechTree ) return;
+
+	var nHighestTime = 0;
+
+	for( var i=rgLaneLog.length-1; i >= 0; i--) {
+		var rgEntry = rgLaneLog[i];
+
+		if( isNaN( rgEntry.time ) ) rgEntry.time = this.m_nActionLogTime + 1;
+
+		if( rgEntry.time <= this.m_nActionLogTime ) continue;
+
+		// If performance concerns arise move the level check out and swap switch for if.
+		switch( rgEntry.type ) {
+			case 'ability':
+				if ( (level % 100 !== 0 && [26].indexOf(rgEntry.ability) > -1) || (level % 100 === 0 && [10, 11, 12, 15, 20].indexOf(rgEntry.ability) > -1) ) {
+					var ele = this.m_eleUpdateLogTemplate.clone();
+					$J(ele).data('abilityid', rgEntry.ability);
+					$J('.name', ele).text(rgEntry.actor_name).attr("style", "color: red; font-weight: bold;");
+					$J('.ability', ele).text(abilities[rgEntry.ability].name + " on level " + level);
+					$J('img', ele).attr('src', g_rgIconMap['ability_' + rgEntry.ability].icon);
+
+					$J(ele).v_tooltip({tooltipClass: 'ta_tooltip', location: 'top'});
+
+					this.m_eleUpdateLogContainer[0].insertBefore(ele[0], this.m_eleUpdateLogContainer[0].firstChild);
+				
+					advLog(rgEntry.actor_name + " used " + s().m_rgTuningData.abilities[ rgEntry.ability ].name + " on level " + level, 1);
+				}
+				break;
+			default:
+				console.log("Unknown action log type: %s", rgEntry.type);
+				console.log(rgEntry);
+		}
+
+		if(rgEntry.time > nHighestTime) nHighestTime = rgEntry.time;
+	}
+
+	if( nHighestTime > this.m_nActionLogTime ) this.m_nActionLogTime = nHighestTime;
+
+	var e = this.m_eleUpdateLogContainer[0];
+	while(e.children.length > 20 ) {
+		e.children[e.children.length-1].remove();
+	}
+};
 
 function disableParticles() {
 	if (w.CSceneGame) {
@@ -1303,6 +1289,12 @@ function toggleTrackTroll(event) {
 
 	if(event !== undefined) {
 		value = handleCheckBox(event);
+	}
+
+	if(value) {
+		CUI.prototype.UpdateLog = localUpdateLog;
+	} else {
+		CUI.prototype.UpdateLog = originalUpdateLog;
 	}
 }
 

--- a/autoplay.noUpdate.user.js
+++ b/autoplay.noUpdate.user.js
@@ -308,6 +308,8 @@ function firstRun() {
 		document.body.style.backgroundPosition = "0 0";
 	}
 
+	originalUpdateLog = CUI.prototype.UpdateLog;
+
 	// Set to match preferences
 	toggleTrackTroll();
 
@@ -369,7 +371,7 @@ function firstRun() {
 }
 
 // Valve's update
-var originalUpdateLog = CUI.prototype.UpdateLog;
+var originalUpdateLog = null;
 
 // The trolltrack
 var localUpdateLog = function( rgLaneLog ) {

--- a/autoplay.noUpdate.user.js
+++ b/autoplay.noUpdate.user.js
@@ -309,7 +309,7 @@ function firstRun() {
 	}
 
 	// Set to match preferences
-	getPreference
+	toggleTrackTroll();
 
 	// Add cool background
 	$J('body.flat_page.game').css('background-image', 'url(http://i.imgur.com/P8TB236.jpg)');

--- a/autoplay.noUpdate.user.js
+++ b/autoplay.noUpdate.user.js
@@ -305,48 +305,60 @@ function firstRun() {
 
 		var nHighestTime = 0;
 
-		for( var i=rgLaneLog.length-1; i >= 0; i--) {
-			var rgEntry = rgLaneLog[i];
+		// Loop for trolltrack
+		if (window.enableTrollTrack) {
+			for(var i=rgLaneLog.length-1; i >= 0; i--) {
+				var rgEntry = rgLaneLog[i];
 
-			if( isNaN( rgEntry.time ) ) rgEntry.time = this.m_nActionLogTime + 1;
+				if( isNaN( rgEntry.time ) ) rgEntry.time = this.m_nActionLogTime + 1;
 
-			if( rgEntry.time <= this.m_nActionLogTime ) continue;
+				if( rgEntry.time <= this.m_nActionLogTime ) continue;
 
-			switch( rgEntry.type ) {
-				case 'ability':
-					if (window.enableTrollTrack) {
-						if ( (level % 100 !== 0 && [26].indexOf(rgEntry.ability) > -1) || (level % 100 === 0 && [10, 11, 12, 15, 20].indexOf(rgEntry.ability) > -1) ) {
-							var ele = this.m_eleUpdateLogTemplate.clone();
-							$J(ele).data('abilityid', rgEntry.ability);
-							$J('.name', ele).text(rgEntry.actor_name).attr("style", "color: red; font-weight: bold;");
-							$J('.ability', ele).text(abilities[rgEntry.ability].name + " on level " + level);
-							$J('img', ele).attr('src', g_rgIconMap['ability_' + rgEntry.ability].icon);
-
-							$J(ele).v_tooltip({tooltipClass: 'ta_tooltip', location: 'top'});
-
-							this.m_eleUpdateLogContainer[0].insertBefore(ele[0], this.m_eleUpdateLogContainer[0].firstChild);
-						
-							advLog(rgEntry.actor_name + " used " + s().m_rgTuningData.abilities[ rgEntry.ability ].name + " on level " + level, 1);
-						}
-					} else {
+				if( rgEntry.type == 'ability' ) {
+					if ( (level % 100 !== 0 && [26].indexOf(rgEntry.ability) > -1) || (level % 100 === 0 && [10, 11, 12, 15, 20].indexOf(rgEntry.ability) > -1) ) {
 						var ele = this.m_eleUpdateLogTemplate.clone();
 						$J(ele).data('abilityid', rgEntry.ability);
-						$J('.name', ele).text(rgEntry.actor_name);
-						$J('.ability', ele).text(abilities[rgEntry.ability].name);
+						$J('.name', ele).text(rgEntry.actor_name).attr("style", "color: red; font-weight: bold;");
+						$J('.ability', ele).text(abilities[rgEntry.ability].name + " on level " + level);
 						$J('img', ele).attr('src', g_rgIconMap['ability_' + rgEntry.ability].icon);
 
 						$J(ele).v_tooltip({tooltipClass: 'ta_tooltip', location: 'top'});
 
 						this.m_eleUpdateLogContainer[0].insertBefore(ele[0], this.m_eleUpdateLogContainer[0].firstChild);
+						
+						advLog(rgEntry.actor_name + " used " + s().m_rgTuningData.abilities[ rgEntry.ability ].name + " on level " + level, 1);
 					}
-					break;
-				default:
-					console.log("Unknown action log type: %s", rgEntry.type);
-					console.log(rgEntry);
+				}
+
+				if(rgEntry.time > nHighestTime) nHighestTime = rgEntry.time;
 			}
 
-			if(rgEntry.time > nHighestTime) nHighestTime = rgEntry.time;
+		// Non-trolltrack
+		} else {
+
+			for(var i=rgLaneLog.length-1; i >= 0; i--) {
+				var rgEntry = rgLaneLog[i];
+
+				if( isNaN( rgEntry.time ) ) rgEntry.time = this.m_nActionLogTime + 1;
+
+				if( rgEntry.time <= this.m_nActionLogTime ) continue;
+
+				if( rgEntry.type == 'ability' ) {
+					var ele = this.m_eleUpdateLogTemplate.clone();
+					$J(ele).data('abilityid', rgEntry.ability);
+					$J('.name', ele).text(rgEntry.actor_name);
+					$J('.ability', ele).text(abilities[rgEntry.ability].name);
+					$J('img', ele).attr('src', g_rgIconMap['ability_' + rgEntry.ability].icon);
+
+					$J(ele).v_tooltip({tooltipClass: 'ta_tooltip', location: 'top'});
+
+					this.m_eleUpdateLogContainer[0].insertBefore(ele[0], this.m_eleUpdateLogContainer[0].firstChild);
+				}
+
+				if(rgEntry.time > nHighestTime) nHighestTime = rgEntry.time;
+			}
 		}
+		
 
 		if( nHighestTime > this.m_nActionLogTime ) this.m_nActionLogTime = nHighestTime;
 
@@ -1217,19 +1229,12 @@ function autoRefreshPage(autoRefreshMinutes){
 }
 
 function autoRefreshHandler() {
-	var enemyData = s().GetEnemy(s().m_rgPlayerData.current_lane, s().m_rgPlayerData.target).m_data;
-	if(typeof enemyData !== "undefined"){
-		var enemyType = enemyData.type;
-		if(enemyType != ENEMY_TYPE.BOSS) {
-			advLog('Refreshing, not boss', 5);
-			w.location.reload(true);
-		}else {
-			advLog('Not refreshing, A boss!', 5);
-			setTimeout(autoRefreshHandler, 3000);
-		}
-	}else{
-		//Wait until it is defined
-		setTimeout(autoRefreshHandler, 1000);
+	if(lastLevelTimeTaken[1].level % 100 == 0) {
+		advLog('Not refreshing (boss level)', 5);
+		setTimeout(autoRefreshHandler, 3000);
+	} else {
+		advLog('Refreshing (not a boss level)', 5);
+		w.location.reload(true);
 	}
 }
 


### PR DESCRIPTION
Regarding a point made yesterday by user 'zylche' in the debug channel I've made some minor modifications.

The first major change is to the troll tracker, removing the internal check from the for loop and just swapping out the function for Valve's when it's disabled (which requires storing Valve's during initialisation, post-load of CUI).

The second change is the boss related check which no longer functioned (and resulted in reloads during mod 100 waves).