### PR TITLE
Enable autorefresh and double refresh time

### DIFF
--- a/autoplay.noUpdate.user.js
+++ b/autoplay.noUpdate.user.js
@@ -2,7 +2,7 @@
 // @name Ye Olde Megajump
 // @namespace https://github.com/YeOldeWH/MonsterMinigameWormholeWarp
 // @description A script that runs the Steam Monster Minigame for you.  Now with megajump.  Brought to you by the Ye Olde Wormhole Schemers and DannyDaemonic
-// @version 7.0.3
+// @version 7.0.4
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
 // @grant none

--- a/autoplay.noUpdate.user.js
+++ b/autoplay.noUpdate.user.js
@@ -44,11 +44,11 @@ var enableFingering = getPreferenceBoolean("enableFingering", true);
 var disableRenderer = getPreferenceBoolean("disableRenderer", true);
 var enableTrollTrack = getPreferenceBoolean("enableTrollTrack", false);
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
-var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info !== "undefined");
+var enableAutoRefresh = true;
 var enableChen = getPreferenceBoolean("enableChen", false);
 
-var autoRefreshMinutes = 15; // Lowering to 15 minutes
-var autoRefreshMinutesRandomDelay = 5; // Lowering to 5 minutes
+var autoRefreshMinutes = 30;
+var autoRefreshMinutesRandomDelay = 10;
 var autoRefreshSecondsCheckLoadedDelay = 30;
 
 var predictTicks = 0;

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
     "_comment" : "This file is used for automatic updates.  Please update with update_version.sh.",
-    "Version" : "7.0.3"
+    "Version" : "7.0.4"
 }


### PR DESCRIPTION
Since autoPlay.user.js no longer refreshes, it's up to the main script to refresh, but hiding the option isn't good enough. Some people may still have it set to false. This forces it to true.

This also doubles the min to 30 minutes and the random to 10.

Includes version bump.